### PR TITLE
feat(US3.7) Add backend endpoints for profile avatar management

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,8 @@
         "@supabase/supabase-js": "^2.76.1",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "multer": "^2.0.2"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "@supabase/supabase-js": "^2.76.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "multer": "^2.0.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"


### PR DESCRIPTION
- Created POST /api/upload-avatar to upload a new profile picture.
  - Converts Base64 image to file, uploads to Supabase Storage.
  - Deletes previous avatar if it exists to avoid duplicates.
  - Updates user's avatar URL in the database.

- Created POST /api/delete-avatar to remove the user's avatar.
  - Deletes image from Supabase Storage.
  - Updates the database to remove avatar URL.

  Related to #14